### PR TITLE
Implement filebrowser service

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a **local-first, fully containerised platform** that he
 4.  AI-powered transcription (Faster-Whisper).
 5.  Local LLM (Ollama) integration for suggesting titles and summaries.
 6.  Automated publishing workflows via n8n webhook triggers.
+7.  Built-in file browser for inspecting uploaded and processed files.
 
 The stack is designed to **run completely on a single workstation** while taking advantage of any NVIDIA/AMD GPU that may be available (GPU usage for Ollama/Whisper is configurable but not explicitly set up in this version). Everything is shipped through **Docker Compose** for reproducible development and deployments.
 
@@ -133,6 +134,7 @@ docker compose down
 - Swagger UI: http://localhost:8000/api/docs
 - ReDoc: http://localhost:8000/api/redoc
 - Health check: http://localhost:8000/api/health
+- File Browser: http://localhost:8090
 
 ### Web Interface Usage
 

--- a/backend/tests/test_api_filebrowser.py
+++ b/backend/tests/test_api_filebrowser.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def create_session(tmp_path: Path, name: str, files: list[str]):
+    session_dir = tmp_path / name
+    session_dir.mkdir()
+    for f in files:
+        (session_dir / f).write_text("data")
+
+
+def test_list_upload_sessions(tmp_path: Path):
+    create_session(tmp_path, "s1", ["a.mp3"])
+    create_session(tmp_path, "s2", [])
+    with patch("app.api.routes_audio.UPLOAD_DIR", tmp_path):
+        resp = client.get("/api/audio/uploads")
+        assert resp.status_code == 200
+        assert set(resp.json()) == {"s1", "s2"}
+
+
+def test_list_files_in_session(tmp_path: Path):
+    create_session(tmp_path, "session123", ["foo.mp3", "bar.wav"])
+    with patch("app.api.routes_audio.UPLOAD_DIR", tmp_path):
+        resp = client.get("/api/audio/uploads/session123")
+        assert resp.status_code == 200
+        assert set(resp.json()) == {"foo.mp3", "bar.wav"}

--- a/changelog/09062025_filebrowser_service.txt
+++ b/changelog/09062025_filebrowser_service.txt
@@ -1,0 +1,5 @@
+feat: add filebrowser service for uploads
+
+- Added `filebrowser` service in `docker-compose.yml` for browsing
+  uploaded and processed files.
+- Documented the service and URL in `README.md`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,18 @@ services:
       - ./frontend:/usr/share/nginx/html:ro # Static front-end SPA
       - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro # Custom proxy & upload limits
 
+  # ---------------------------------------------------------------------------
+  # Filebrowser – simple UI to browse uploaded files
+  # ---------------------------------------------------------------------------
+  filebrowser:
+    image: filebrowser/filebrowser:s6
+    container_name: podcaster-filebrowser
+    volumes:
+      - ./data:/srv
+    ports:
+      - "8090:80"
+    restart: unless-stopped
+
 volumes:
   pgdata:
   ollama_models:


### PR DESCRIPTION
## Summary
- add a Filebrowser container to docker-compose
- document the new service in README
- test upload session listing APIs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684749a6b04883238e626835b9e455ef