### PR TITLE
Implement n8n workflow automation service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,11 @@ CELERY_RESULT_BACKEND=redis://broker:6379/1
 OLLAMA_URL=http://ollama:11434
 
 # n8n ------------------------------------------------------------------------
+N8N_BASIC_AUTH_ACTIVE=true
 N8N_BASIC_AUTH_USER=admin
 N8N_BASIC_AUTH_PASSWORD=admin
+N8N_WEBHOOK_URL=http://n8n:5678/webhook/test
+N8N_API_KEY=
   
 # Frontend --------------------------------------------------------------------
 FRONTEND_PORT=3005

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Follow these steps to set up and run The Podcaster locally.
    ```bash
    docker exec -it podcaster-ollama ollama pull llama2:7b-chat
    ```
+4. (Optional) Adjust n8n credentials and webhook URL in `.env` if you plan to
+   use the automated publishing features. The service is started automatically
+   by `docker compose`.
 
 ### Important: Data Directory Permissions
 
@@ -135,6 +138,7 @@ docker compose down
 - ReDoc: http://localhost:8000/api/redoc
 - Health check: http://localhost:8000/api/health
 - File Browser: http://localhost:8090
+- n8n Workflow UI: http://localhost:5678 (protected by basic auth)
 
 ### Web Interface Usage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ Deliverable: MP4/WEBM video ready for YouTube.
 
 | ID | Task | Est. | Notes |
 |----|------|------|-------|
-|F1|Add n8n container to Compose|0.25d|
+|F1|Add n8n container to Compose|0.25d|Implemented. Service enabled in docker-compose with basic auth variables.|
 |F2|Provide sample YouTube upload workflow|0.5d|Secrets via `.env`|
 |F3|Trigger n8n via webhook when processing completes|0.5d|
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,6 +36,8 @@ class Settings:
     CELERY_RESULT_BACKEND: str = os.getenv('CELERY_RESULT_BACKEND') or 'redis://broker:6379/0'
     OLLAMA_URL: str = os.getenv('OLLAMA_URL') or ''
     OLLAMA_DEFAULT_MODEL: str = os.getenv('OLLAMA_DEFAULT_MODEL') or ''
+    N8N_WEBHOOK_URL: str = os.getenv('N8N_WEBHOOK_URL') or ''
+    N8N_API_KEY: str = os.getenv('N8N_API_KEY') or ''
     FRONTEND_PORT: int = int(os.getenv('FRONTEND_PORT') or '80')
     DB_ECHO: bool = (os.getenv('DB_ECHO') or 'false').lower() in ('1', 'true', 'yes')
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,4 +18,5 @@ faster-whisper==1.0.1
 requests==2.32.2
 python-dotenv==1.0.1
 httpx==0.27.0
-pytest # For running tests
+pytest
+pytest-asyncio

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -13,3 +13,16 @@ def test_settings_from_env(monkeypatch):
     with database.engine.connect() as conn:
         result = conn.execute(text("SELECT 1")).scalar()
         assert result == 1
+
+
+def test_n8n_settings(monkeypatch):
+    monkeypatch.setenv("N8N_WEBHOOK_URL", "http://n8n:5678/webhook/test")
+    monkeypatch.setenv("N8N_API_KEY", "secret")
+
+    from importlib import reload
+    from app import config as config_module
+
+    reload(config_module)
+
+    assert config_module.settings.N8N_WEBHOOK_URL == "http://n8n:5678/webhook/test"
+    assert config_module.settings.N8N_API_KEY == "secret"

--- a/backend/tests/test_service_publish.py
+++ b/backend/tests/test_service_publish.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+from importlib import reload
+
+from app.models.job import ProcessingJob, JobStatus
+from app.models.llm import LLMSuggestion
+from backend.app import config as config_module
+
+# reload config to apply env vars in each test
+
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient.post", new_callable=AsyncMock)
+async def test_trigger_n8n_workflow_success(mock_post, monkeypatch):
+    monkeypatch.setenv("N8N_WEBHOOK_URL", "http://n8n:5678/webhook/test")
+    monkeypatch.setenv("N8N_API_KEY", "secret")
+    reload(config_module)
+    import sys
+    sys.modules['backend.app.models.job'] = sys.modules['app.models.job']
+    sys.modules['backend.app.models.llm'] = sys.modules['app.models.llm']
+    sys.modules['backend.app.models.audio'] = sys.modules['app.models.audio']
+    sys.modules['backend.app.models.transcript'] = sys.modules['app.models.transcript']
+    from app.services import publish
+    monkeypatch.setattr(publish, "settings", config_module.settings)
+
+    job = ProcessingJob(id=1, job_type="video_generation", status=JobStatus.COMPLETED,
+                        output_file_path="outputs/out.mp4")
+    job.input_file_path = "uploads/in.mp3"
+    job.created_at = datetime.utcnow()
+
+    suggestion = MagicMock()
+    suggestion.get_titles.return_value = ["T1"]
+    suggestion.suggested_summary = "S"
+    suggestion.job = job
+
+    def query_side_effect(model):
+        q = MagicMock()
+        if model is LLMSuggestion:
+            q.filter.return_value.order_by.return_value.first.return_value = suggestion
+        elif model is ProcessingJob:
+            q.filter.return_value.first.return_value = job
+        return q
+
+    db = MagicMock()
+    db.query.side_effect = query_side_effect
+
+    mock_response = AsyncMock()
+    mock_response.json.return_value = {"ok": True}
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    result = await publish.trigger_n8n_workflow(job, db)
+    assert result["success"] is True
+    mock_post.assert_called_once()
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["job_id"] == 1
+    assert payload["media_type"] == "video"
+
+
+@pytest.mark.asyncio
+async def test_trigger_n8n_workflow_no_url(monkeypatch):
+    monkeypatch.delenv("N8N_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("N8N_API_KEY", raising=False)
+    reload(config_module)
+    import sys
+    sys.modules['backend.app.models.job'] = sys.modules['app.models.job']
+    sys.modules['backend.app.models.llm'] = sys.modules['app.models.llm']
+    sys.modules['backend.app.models.audio'] = sys.modules['app.models.audio']
+    sys.modules['backend.app.models.transcript'] = sys.modules['app.models.transcript']
+    from app.services import publish
+    monkeypatch.setattr(publish, "settings", config_module.settings)
+
+    job = ProcessingJob(id=2, job_type="video_generation", status=JobStatus.COMPLETED)
+    db = MagicMock()
+
+    with pytest.raises(ValueError):
+        await publish.trigger_n8n_workflow(job, db)

--- a/changelog/10062025_enable_n8n_service.txt
+++ b/changelog/10062025_enable_n8n_service.txt
@@ -1,0 +1,4 @@
+- Enabled n8n container in `docker-compose.yml` with basic auth variables.
+- Added `N8N_WEBHOOK_URL` and `N8N_API_KEY` config options and `.env.example` entries.
+- Updated README with n8n setup notes and UI link.
+- Marked roadmap item F1 as implemented.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,22 +93,22 @@ services:
  #      - ollama_models:/root/.ollama
 
   # ---------------------------------------------------------------------------
-  # n8n – workflow automation (optional, comment until Milestone 6)
+  # n8n – workflow automation
   # ---------------------------------------------------------------------------
- #  n8n:
- #    image: n8nio/n8n:latest
- #    container_name: podcaster-n8n
- #    restart: unless-stopped
- #    ports:
- #      - "5678:5678"
- #    environment:
- #      - N8N_BASIC_AUTH_ACTIVE=true   # <-- Change credentials in .env
- #      - N8N_BASIC_AUTH_USER=admin
- #      - N8N_BASIC_AUTH_PASSWORD=admin
- #    volumes:
- #      - n8n_data:/home/node/.n8n
- #    depends_on:
- #      - db
+  n8n:
+    image: n8nio/n8n:latest
+    container_name: podcaster-n8n
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=${N8N_BASIC_AUTH_ACTIVE:-true}
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD}
+    volumes:
+      - n8n_data:/home/node/.n8n
+    depends_on:
+      - db
 
   # ---------------------------------------------------------------------------
   # Front-end – placeholder Nginx serving AudioMass static build


### PR DESCRIPTION
## Summary
- enable n8n container in docker-compose
- add N8N settings to config and environment example
- document n8n in README and mark roadmap item F1 as complete
- add tests for new config options and n8n publish service
- include dependency `pytest-asyncio`

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest backend/tests/test_service_publish.py -q`
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_6848918fb1dc8323a5b76f3160240157